### PR TITLE
Allows for skipping the generation of some pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,25 @@ The easiest (though a bit gimmicky) solution is adding the following conditional
 ### CSS
 CSS rules for AMP must be included inline in the `<style amp-custom>` tag in the `<head>` element in the HTML. You can write the CSS rules by hand or use jekyll includes. Do note that the AMP specification forbids the use of some CSS selectors and attributes. Because of this, it is not a good idea to include the main stylesheet by default.
 
+### Skipping Pages
+
+Sometimes there are pages we don't want to be turned into AMP pages, normally this is because they require HTML elements or JavaScript that would make them invalid.
+
+In any post we want to skip simply add;
+
+```
+skip_amp: true
+```
+
+And update your `amphtml` block to look like;
+
+```
+{% if page.path contains '_posts' %}
+  {% unless page.skip_amp %}
+    <link rel="amphtml" href="{{ page.id | prepend: '/YOURDIR' | prepend: site.baseurl | prepend: site.url }}">
+  {% endunless %}
+{% endif %}
+```
+
 [nokogiri]: http://www.nokogiri.org/
 [fastimage]: https://github.com/sdsykes/fastimage

--- a/amp_generate.rb
+++ b/amp_generate.rb
@@ -22,6 +22,7 @@ module Jekyll
     def generate(site)
       dir = site.config['ampdir'] || 'amp'
       site.posts.docs.each do |post|
+        next if post.data['skip_amp'] == true
         index = AmpPost.new(site, site.source, File.join(dir, post.id), post)
         index.render(site.layouts, site.site_payload)
         index.write(site.dest)


### PR DESCRIPTION
An issue I and I am sure many others have experienced is that some posts just don't make good AMP pages.

If your post requires certain elements to be present on a page or for particular CSS/JavaScript to be used there is little that can be done to make it a workable AMP page.

This PR updates the README to explain how you can skip posts, and adds one line of code that will stop these marked pages from being generated.

I could have made the one line more concise by removing the `== true` but I wanted it to only happen on the actual `true` value, not just any truthy value.

Any questions or concerns let me know 😄 