### PR TITLE
compatibility with jekyll-assets

### DIFF
--- a/amp_filter.rb
+++ b/amp_filter.rb
@@ -21,7 +21,7 @@ module Jekyll
           else
             # FastImage doesn't seem to handle local paths when used with Jekyll
             # so let's just force the path
-            src = File.join(Dir.pwd, image['src'])
+            src = File.join(Dir.pwd + '_site', image['src'])
           end
           # Jekyll generates static assets after the build process.
           # This causes problems when trying to determine the dimensions of a locally stored image.

--- a/amp_filter.rb
+++ b/amp_filter.rb
@@ -21,7 +21,7 @@ module Jekyll
           else
             # FastImage doesn't seem to handle local paths when used with Jekyll
             # so let's just force the path
-            src = File.join(Dir.pwd + '_site', image['src'])
+            src = File.join(Dir.pwd, '_site', image['src'])
           end
           # Jekyll generates static assets after the build process.
           # This causes problems when trying to determine the dimensions of a locally stored image.


### PR DESCRIPTION
Changes the image file path. This allows source images to live in _assets and enable compatibility with https://github.com/jekyll/jekyll-assets

before: `~/myblog/assets/img/image.png`

after: `~/myblog/_site/assets/img/image.png`