### PR TITLE
Uses master post and URL to set @url and @name.

### DIFF
--- a/lib/jekyll/amp_generate.rb
+++ b/lib/jekyll/amp_generate.rb
@@ -1,13 +1,16 @@
 module Jekyll
   # Defines the base class of AMP posts
   class AmpPost < Page
-    def initialize(site, base, dir, post)
+    def initialize(site, base, dir, post, amp_root_dir)
       @site = site
       @base = base
       @dir = dir
       # Needed for posts with permalink
-      @url = dir
-      @name = 'index.html'
+      @url ||= URL.new({
+        :template     => File.join(amp_root_dir, post.url_template),
+        :placeholders => post.url_placeholders
+      }).to_s
+      @name = post.basename
       self.process(@name)
       self.read_yaml(File.join(base, '_layouts'), 'amp.html')
       self.content               = post.content
@@ -33,7 +36,7 @@ module Jekyll
       dir = site.config['ampdir'] || 'amp'
       site.posts.docs.each do |post|
         next if post.data['skip_amp'] == true
-        site.pages << AmpPost.new(site, site.source, File.join(dir, post.id), post)
+        site.pages << AmpPost.new(site, site.source, File.join(dir, post.id), post, dir)
       end
     end
   end


### PR DESCRIPTION
Hi.  I've been using your `amp-jekyll` plugin on a blog, but I've had a problem when using it with the `jekyll-sitemap` plugin.  The AMP files were added to the sitemap, but the `.html` extension for the generated AMP posts was excluded, meaning the sitemap links where broken.  This is because the `jekyll-sitemap` plugin uses `Jekyll::Page#url` to output the `<loc>` of each post in the generated sitemap, and `amp-jekyll` overrides `@url` with `dir`, which doesn't include the extension.

I've made this change, which uses the `Jekyll::URL` class to set `@url` in the `Jekyll::AmpPage` constructor.  This fixes my problem above.  I don't know whether this negatively impacts things elsewhere though... :S 

Does this work as a general enhancement to `amp-jekyll`?  I can tidy up the changes, such as constructor args if it does.