### PR TITLE
Fix undefined method 'liquid_renderer' for nil:NilClass

### DIFF
--- a/lib/jekyll/amp_generate.rb
+++ b/lib/jekyll/amp_generate.rb
@@ -1,6 +1,6 @@
 module Jekyll
   # Defines the base class of AMP posts
-  class AmpPost < Page
+  class AmpPost < Jekyll::Page
     def initialize(site, base, dir, post)
       @site = site
       @base = base


### PR DESCRIPTION
Hi there,

I implemented the plugin on my website but I got the following error on `jekyll server`:
```ruby
undefined method liquid_renderer for nil:NilClass
```

It seems the error is related to **amp_generate.rb** file on *line 3*.

I changed:

`class AmpPost < Page`

to 

`class AmpPost < Jekyll::Page`

and it worked.