### PR TITLE
Includes excerpt in AmpPage data

### DIFF
--- a/lib/jekyll/amp_generate.rb
+++ b/lib/jekyll/amp_generate.rb
@@ -16,9 +16,6 @@ module Jekyll
       # Merge all data from post so that keys from self.data have higher priority
       self.data = post.data.merge(self.data)
 
-      # Remove non needed keys from data
-      # Excerpt will cause an error if kept
-      self.data.delete('excerpt')
       # Generating the page fails silently if page has a permalink and it is copied
       # over to the AMP version
       self.data.delete('permalink')


### PR DESCRIPTION
Hi,

What's the reason for removing the `excerpt` key from data?  Is it possible to remove the line that you included here?

I'd like to include this so that the meta description in my AMP posts is unique.  If the `excerpt` key in data must be removed is there an alternative way to get the excerpt for the underlying post on the AmpPost?

Thanks